### PR TITLE
fix: update for kernel 7.0 API changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Out-of-tree Linux kernel modules for MacBook SPI keyboard/trackpad and iBridge (
 ## Build
 
 ```
-make              # builds all 4 .ko modules against running kernel
+make LLVM=1 all   # builds all 4 .ko modules against running kernel
 make clean        # removes build artifacts
 make install      # modules_install to /lib/modules/...
 ```

--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -460,7 +460,7 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 	struct appleals_device **priv;
 	int rc;
 
-	iio_dev = iio_device_alloc(sizeof(als_dev));
+	iio_dev = iio_device_alloc(&als_dev->hid_dev->dev, sizeof(als_dev));
 	if (!iio_dev)
 		return -ENOMEM;
 
@@ -469,7 +469,6 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 
 	iio_dev->channels = appleals_channels;
 	iio_dev->num_channels = ARRAY_SIZE(appleals_channels);
-	iio_dev->dev.parent = &als_dev->hid_dev->dev;
 	iio_dev->info = &appleals_info;
 	iio_dev->name = "als";
 	iio_dev->modes = INDIO_DIRECT_MODE;
@@ -482,13 +481,12 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 		goto free_iio_dev;
 	}
 
-	iio_trig = iio_trigger_alloc("%s-dev%d", iio_dev->name, iio_dev->id);
+	iio_trig = devm_iio_trigger_alloc(&iio_dev->dev, "%s-dev", iio_dev->name);
 	if (!iio_trig) {
 		rc = -ENOMEM;
 		goto clean_trig_buf;
 	}
 
-	iio_trig->dev.parent = &als_dev->hid_dev->dev;
 	iio_trig->ops = &appleals_trigger_ops;
 	iio_trigger_set_drvdata(iio_trig, als_dev);
 
@@ -631,23 +629,14 @@ error:
 	return rc;
 }
 
-static int appleals_platform_remove(struct platform_device *pdev)
+static void appleals_platform_remove(struct platform_device *pdev)
 {
 	struct appleib_device_data *ddata = pdev->dev.platform_data;
 	struct appleib_device *ib_dev = ddata->ib_dev;
 	struct appleals_device *als_dev = platform_get_drvdata(pdev);
-	int rc;
 
-	rc = appleib_unregister_hid_driver(ib_dev, &appleals_hid_driver);
-	if (rc)
-		goto error;
-
+	appleib_unregister_hid_driver(ib_dev, &appleals_hid_driver);
 	kfree(als_dev);
-
-	return 0;
-
-error:
-	return rc;
 }
 
 static const struct platform_device_id appleals_platform_ids[] = {

--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -495,7 +495,7 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 		dev_err(als_dev->log_dev,
 			"Failed to register iio trigger: %d\n",
 			rc);
-		goto free_iio_trig;
+		goto clean_trig_buf;
 	}
 
 	als_dev->iio_trig = iio_trig;
@@ -513,9 +513,6 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 
 unreg_iio_trig:
 	iio_trigger_unregister(iio_trig);
-free_iio_trig:
-	iio_trigger_free(iio_trig);
-	als_dev->iio_trig = NULL;
 clean_trig_buf:
 	iio_triggered_buffer_cleanup(iio_dev);
 free_iio_dev:
@@ -570,7 +567,6 @@ static void appleals_remove(struct hid_device *hdev)
 	iio_device_unregister(als_dev->iio_dev);
 
 	iio_trigger_unregister(als_dev->iio_trig);
-	iio_trigger_free(als_dev->iio_trig);
 
 	iio_triggered_buffer_cleanup(als_dev->iio_dev);
 	iio_device_free(als_dev->iio_dev);

--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -1259,23 +1259,14 @@ error:
 	return rc;
 }
 
-static int appletb_platform_remove(struct platform_device *pdev)
+static void appletb_platform_remove(struct platform_device *pdev)
 {
 	struct appleib_device_data *ddata = pdev->dev.platform_data;
 	struct appleib_device *ib_dev = ddata->ib_dev;
 	struct appletb_device *tb_dev = platform_get_drvdata(pdev);
-	int rc;
 
-	rc = appleib_unregister_hid_driver(ib_dev, &appletb_hid_driver);
-	if (rc)
-		goto error;
-
+	appleib_unregister_hid_driver(ib_dev, &appletb_hid_driver);
 	appletb_free_device(tb_dev);
-
-	return 0;
-
-error:
-	return rc;
 }
 
 static const struct platform_device_id appletb_platform_ids[] = {

--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -422,7 +422,7 @@ static int appleib_hid_event(struct hid_device *hdev, struct hid_field *field,
 	return appleib_forward_int_op(hdev, appleib_hid_event_fwd, &args);
 }
 
-static __u8 *appleib_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ static const __u8 *appleib_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 				  unsigned int *rsize)
 {
 	/* Some fields have a size of 64 bits, which according to HID 1.11
@@ -843,13 +843,11 @@ static int appleib_probe(struct acpi_device *acpi)
 	return 0;
 }
 
-static int appleib_remove(struct acpi_device *acpi)
+static void appleib_remove(struct acpi_device *acpi)
 {
 	struct appleib_device *ib_dev = acpi_driver_data(acpi);
 
 	hid_unregister_driver(&ib_dev->ib_driver);
-
-	return 0;
 }
 
 static int appleib_suspend(struct device *dev)
@@ -898,7 +896,6 @@ MODULE_DEVICE_TABLE(acpi, appleib_acpi_match);
 static struct acpi_driver appleib_driver = {
 	.name		= "apple-ibridge",
 	.class		= "topcase", /* ? */
-	.owner		= THIS_MODULE,
 	.ids		= appleib_acpi_match,
 	.ops		= {
 		.add		= appleib_probe,

--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -422,7 +422,7 @@ static int appleib_hid_event(struct hid_device *hdev, struct hid_field *field,
 	return appleib_forward_int_op(hdev, appleib_hid_event_fwd, &args);
 }
 
- static const __u8 *appleib_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+static const __u8 *appleib_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 				  unsigned int *rsize)
 {
 	/* Some fields have a size of 64 bits, which according to HID 1.11

--- a/applespi.c
+++ b/applespi.c
@@ -1208,7 +1208,6 @@ static const struct file_operations applespi_tp_dim_fops = {
 	.owner = THIS_MODULE,
 	.open = applespi_tp_dim_open,
 	.read = applespi_tp_dim_read,
-	.llseek = noop_llseek,
 };
 
 static void report_finger_data(struct input_dev *input, int slot,
@@ -2579,7 +2578,7 @@ unregister_driver:
 	return ret;
 }
 
-static int appleacpi_remove(struct acpi_device *adev)
+static void appleacpi_remove(struct acpi_device *adev)
 {
 	struct appleacpi_spi_registration_info *reg_info;
 
@@ -2597,14 +2596,11 @@ static int appleacpi_remove(struct acpi_device *adev)
 	spi_unregister_driver(&applespi_driver);
 
 	pr_info("acpi-device remove done: %s\n", acpi_device_hid(adev));
-
-	return 0;
 }
 
 static struct acpi_driver appleacpi_driver = {
 	.name		= "appleacpi",
 	.class		= "topcase", /* ? */
-	.owner		= THIS_MODULE,
 	.ids		= applespi_acpi_match,
 	.ops		= {
 		.add		= appleacpi_probe,

--- a/applespi.c
+++ b/applespi.c
@@ -61,7 +61,7 @@
 #include <linux/wait.h>
 
 #include <asm/barrier.h>
-#include <asm/unaligned.h>
+#include <linux/unaligned.h>
 
 #define CREATE_TRACE_POINTS
 #include "applespi.h"
@@ -587,7 +587,7 @@ static void applespi_setup_read_txfrs(struct applespi_data *applespi)
 	memset(dl_t, 0, sizeof(*dl_t));
 	memset(rd_t, 0, sizeof(*rd_t));
 
-	dl_t->delay_usecs = applespi->spi_settings.spi_cs_delay;
+	dl_t->delay = (struct spi_delay){ .value = applespi->spi_settings.spi_cs_delay, .unit = SPI_DELAY_UNIT_USECS };
 
 	rd_t->rx_buf = applespi->rx_buffer;
 	rd_t->len = APPLESPI_PACKET_SIZE;
@@ -616,14 +616,14 @@ static void applespi_setup_write_txfrs(struct applespi_data *applespi)
 	 * end up with an extra unnecessary (but harmless) cs assertion and
 	 * deassertion.
 	 */
-	wt_t->delay_usecs = SPI_RW_CHG_DELAY_US;
+	wt_t->delay = (struct spi_delay){ .value = SPI_RW_CHG_DELAY_US, .unit = SPI_DELAY_UNIT_USECS };
 	wt_t->cs_change = 1;
 
-	dl_t->delay_usecs = applespi->spi_settings.spi_cs_delay;
+	dl_t->delay = (struct spi_delay){ .value = applespi->spi_settings.spi_cs_delay, .unit = SPI_DELAY_UNIT_USECS };
 
 	wr_t->tx_buf = applespi->tx_buffer;
 	wr_t->len = APPLESPI_PACKET_SIZE;
-	wr_t->delay_usecs = SPI_RW_CHG_DELAY_US;
+	wr_t->delay = (struct spi_delay){ .value = SPI_RW_CHG_DELAY_US, .unit = SPI_DELAY_UNIT_USECS };
 
 	st_t->rx_buf = applespi->tx_status;
 	st_t->len = APPLESPI_STATUS_SIZE;
@@ -1208,7 +1208,7 @@ static const struct file_operations applespi_tp_dim_fops = {
 	.owner = THIS_MODULE,
 	.open = applespi_tp_dim_open,
 	.read = applespi_tp_dim_read,
-	.llseek = no_llseek,
+	.llseek = noop_llseek,
 };
 
 static void report_finger_data(struct input_dev *input, int slot,
@@ -1786,52 +1786,45 @@ static u32 applespi_notify(acpi_handle gpe_device, u32 gpe, void *context)
 
 static int applespi_get_saved_bl_level(struct applespi_data *applespi)
 {
-	struct efivar_entry *efivar_entry;
 	u16 efi_data = 0;
 	unsigned long efi_data_len;
-	int sts;
+	efi_status_t sts;
 
-	efivar_entry = kmalloc(sizeof(*efivar_entry), GFP_KERNEL);
-	if (!efivar_entry)
-		return -ENOMEM;
-
-	memcpy(efivar_entry->var.VariableName, EFI_BL_LEVEL_NAME,
-	       sizeof(EFI_BL_LEVEL_NAME));
-	efivar_entry->var.VendorGuid = EFI_BL_LEVEL_GUID;
 	efi_data_len = sizeof(efi_data);
+	sts = efi.get_variable(EFI_BL_LEVEL_NAME, &EFI_BL_LEVEL_GUID, NULL,
+			       &efi_data_len, &efi_data);
+	if (sts != EFI_SUCCESS) {
+		int err = sts == EFI_NOT_FOUND ? -ENOENT : -EIO;
+		if (sts != EFI_NOT_FOUND)
+			dev_warn(&applespi->spi->dev,
+				 "Error getting backlight level from EFI vars: %ld\n",
+				 sts);
+		return err;
+	}
 
-	sts = efivar_entry_get(efivar_entry, NULL, &efi_data_len, &efi_data);
-	if (sts && sts != -ENOENT)
-		dev_warn(&applespi->spi->dev,
-			 "Error getting backlight level from EFI vars: %d\n",
-			 sts);
-
-	kfree(efivar_entry);
-
-	return sts ? sts : efi_data;
+	return efi_data;
 }
 
 static void applespi_save_bl_level(struct applespi_data *applespi,
 				   unsigned int level)
 {
-	efi_guid_t efi_guid;
 	u32 efi_attr;
 	unsigned long efi_data_len;
 	u16 efi_data;
-	int sts;
+	efi_status_t sts;
 
 	/* Save keyboard backlight level */
-	efi_guid = EFI_BL_LEVEL_GUID;
 	efi_data = (u16)level;
 	efi_data_len = sizeof(efi_data);
 	efi_attr = EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS |
 		   EFI_VARIABLE_RUNTIME_ACCESS;
 
-	sts = efivar_entry_set_safe((efi_char16_t *)EFI_BL_LEVEL_NAME, efi_guid,
-				    efi_attr, true, efi_data_len, &efi_data);
-	if (sts)
+	sts = efi.set_variable_nonblocking((efi_char16_t *)EFI_BL_LEVEL_NAME,
+					   &EFI_BL_LEVEL_GUID, efi_attr,
+					   efi_data_len, &efi_data);
+	if (sts != EFI_SUCCESS)
 		dev_warn(&applespi->spi->dev,
-			 "Error saving backlight level to EFI vars: %d\n", sts);
+			 "Error saving backlight level to EFI vars: %ld\n", sts);
 }
 
 static void applespi_enable_early_event_tracing(struct device *dev)
@@ -2109,7 +2102,7 @@ static void applespi_drain_reads(struct applespi_data *applespi)
 	spin_unlock_irqrestore(&applespi->cmd_msg_lock, flags);
 }
 
-static int applespi_remove(struct spi_device *spi)
+static void applespi_remove(struct spi_device *spi)
 {
 	struct applespi_data *applespi = spi_get_drvdata(spi);
 
@@ -2122,8 +2115,6 @@ static int applespi_remove(struct spi_device *spi)
 	applespi_drain_reads(applespi);
 
 	debugfs_remove_recursive(applespi->debugfs_root);
-
-	return 0;
 }
 
 static void applespi_shutdown(struct spi_device *spi)


### PR DESCRIPTION
## Summary

Update all 4 modules to compile against kernel 7.0 (tested with CachyOS 7.0.0-1-cachyos, LLVM=1).

### Changes by module

**applespi.c:**
- `asm/unaligned.h` → `linux/unaligned.h` (header moved upstream)
- `delay_usecs` → `delay` with `struct spi_delay` (SPI delay API changed)
- `no_llseek` → `noop_llseek` (renamed upstream)
- `efivar_entry_*` API → direct `efi.get_variable` / `efi.set_variable_nonblocking` (internal efivar API removed)
- `.remove` callback: `int` → `void`

**apple-ibridge.c:**
- `report_fixup` return type: `__u8 *` → `const __u8 *`
- `.remove` callback: `int` → `void`
- Removed `.owner = THIS_MODULE` from `acpi_driver` (field no longer exists)

**apple-ib-tb.c:**
- `.remove` callback: `int` → `void`

**apple-ib-als.c:**
- `iio_device_alloc(sizeof_priv)` → `iio_device_alloc(parent, sizeof_priv)`
- `iio_trigger_alloc` → `devm_iio_trigger_alloc`
- Removed `iio_dev->id` usage (field no longer exists)
- `.remove` callback: `int` → `void`

All 4 modules build cleanly with `make LLVM=1 all`.