### PR TITLE
feat: add DKMS package support with pacman PKGBUILD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *.ko
 *.so
 *.so.dbg
+*.mod
 *.mod.c
 *.i
 *.lst

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,25 @@ endif
 KDIR := /lib/modules/$(KVERSION)/build
 PWD := $(shell pwd)
 
+# Auto-detect clang/LLVM
+# Usage: make (auto-detect) | make LLVM=1 (force clang) | make LLVM=0 (force gcc)
+# Strip LLVM from MAKEOVERRIDES so command-line LLVM=0 doesn't leak
+# to kbuild via MAKEFLAGS (kbuild's ifdef LLVM treats any value as true)
+MAKEOVERRIDES := $(filter-out LLVM=% LLVM_IAS=%,$(MAKEOVERRIDES))
+
+_USE_LLVM :=
+ifeq ($(origin LLVM), undefined)
+  ifneq ($(shell which clang 2>/dev/null),)
+    _USE_LLVM := 1
+  endif
+else ifeq ($(LLVM),1)
+  _USE_LLVM := 1
+endif
+
 all:
-	$(MAKE) -C $(KDIR) M=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) $(if $(_USE_LLVM),LLVM=1 LLVM_IAS=1,LLVM= LLVM_IAS=) modules
+
+modules: all
 
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean
@@ -25,3 +42,20 @@ test: all
 	sync
 	-rmmod applespi
 	insmod ./applespi.ko
+
+check_deps:
+	@echo "Checking dependencies..."
+	@if ! command -v clang >/dev/null 2>&1; then echo "ERROR: clang not found. Install with: sudo pacman -S clang" >&2; exit 1; fi
+	@if ! command -v makepkg >/dev/null 2>&1; then echo "ERROR: makepkg not found. Install with: sudo pacman -S devtools" >&2; exit 1; fi
+	@if [ ! -f "PKGBUILD" ]; then echo "ERROR: PKGBUILD not found" >&2; exit 1; fi
+	@if [ ! -f "dkms.conf" ]; then echo "ERROR: dkms.conf not found" >&2; exit 1; fi
+	@echo "All dependencies available."
+
+dkms: all check_deps
+	@echo "=== DKMS Deployment ==="
+	@echo "Building DKMS package with makepkg..."
+	makepkg -f
+	@echo ""
+	@echo "DKMS package created!"
+
+.PHONY: all clean install test dkms check_deps modules

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Ronny F. <ronnyf@icloud.com>
+
+_pkgname=macbook12-spi-driver
+pkgname=applespi-dkms
+pkgver=0.1
+pkgrel=1
+pkgdesc="Apple MacBook SPI keyboard/trackpad and iBridge drivers (DKMS)"
+arch=('x86_64')
+url="https://github.com/ronnyf/macbook12-spi-driver"
+license=('GPL2')
+depends=('dkms' 'linux-headers')
+makedepends=('clang')
+optdepends=()
+install=applespi.install
+
+source=("$pkgname-$pkgver.tar.gz::https://github.com/ronnyf/macbook12-spi-driver/archive/refs/heads/main.tar.gz"
+        "dkms.conf")
+md5sums=('SKIP'
+         'SKIP')
+
+prepare() {
+    cd "$srcdir/$_pkgname-main"
+    cp "$srcdir/dkms.conf" .
+}
+
+build() {
+    echo "Build phase: DKMS will compile during installation"
+}
+
+package() {
+    cd "$srcdir/$_pkgname-main"
+
+    local dkms_dest="$pkgdir/usr/src/$pkgname-$pkgver"
+
+    install -dm 755 "$dkms_dest"
+    cp applespi.c applespi.h applespi_trace.h "$dkms_dest/"
+    cp apple-ibridge.c apple-ibridge.h "$dkms_dest/"
+    cp apple-ib-tb.c "$dkms_dest/"
+    cp apple-ib-als.c "$dkms_dest/"
+    cp Makefile "$dkms_dest/"
+    install -Dm 644 dkms.conf "$dkms_dest/dkms.conf"
+}

--- a/applespi.install
+++ b/applespi.install
@@ -1,0 +1,29 @@
+pre_install() {
+    # Remove manually installed kernel modules to avoid conflicts
+    # applespi is upstream (kernel 5.3+), iBridge modules are out-of-tree
+    rm -f /lib/modules/*/kernel/drivers/input/keyboard/applespi.ko* 2>/dev/null || true
+    rm -rf /lib/modules/*/kernel/extra/apple-ibridge.ko* 2>/dev/null || true
+    rm -rf /lib/modules/*/kernel/extra/apple-ib-tb.ko* 2>/dev/null || true
+    rm -rf /lib/modules/*/kernel/extra/apple-ib-als.ko* 2>/dev/null || true
+}
+
+post_install() {
+    if command -v dkms >/dev/null 2>&1; then
+        echo ">>> DKMS is installed — modules will auto-rebuild on kernel updates."
+    else
+        echo ">>> Install dkms for automatic module rebuild on kernel updates:"
+        echo ">>>   sudo pacman -S dkms"
+    fi
+}
+
+pre_upgrade() {
+    pre_install
+}
+
+post_upgrade() {
+    post_install
+}
+
+post_remove() {
+    : # nothing to clean up
+}

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="applespi"
 PACKAGE_VERSION="0.1"
 CLEAN="make clean"
-MAKE="make"
+MAKE="make modules"
 BUILT_MODULE_NAME[0]="applespi"
 BUILT_MODULE_NAME[1]="apple-ibridge"
 BUILT_MODULE_NAME[2]="apple-ib-tb"

--- a/docs/plans/dkms-target.md
+++ b/docs/plans/dkms-target.md
@@ -1,0 +1,58 @@
+# Add `make dkms` Target — Pacman PKGBUILD Approach
+
+## Goal
+Add a `make dkms` target that produces an installable pacman DKMS package (`applespi-dkms`), following the AIC8800-Linux-Driver pattern.
+
+## Files Changed/Created
+
+### `Makefile`
+- Added clang auto-detect (lines 15-26): auto-uses clang if available, `make LLVM=1` forces, `LLVM=0` forces gcc
+- Added `modules: all` alias target for DKMS compatibility
+- Added `check_deps` target: verifies clang, makepkg, PKGBUILD, dkms.conf
+- Added `dkms` target: builds modules, checks deps, runs `makepkg -f`
+- Updated `.PHONY`
+
+### `dkms.conf`
+- Changed `MAKE="make"` → `MAKE="make modules"` (explicit target)
+
+### `PKGBUILD` (new)
+- Package name: `applespi-dkms`, version `0.1-1`
+- Source: GitHub tarball + local dkms.conf
+- `prepare()`: copies dkms.conf into extracted source
+- `package()`: copies all .c/.h + Makefile + dkms.conf to `/usr/src/applespi-dkms-0.1/`
+- Dependencies: `dkms`, `linux-headers`, `clang` (makedepends)
+
+### `applespi.install` (new)
+- `pre_install`: removes manually installed modules (applespi from `drivers/input/keyboard/`, iBridge from `extra/`)
+- `post_install`: checks for dkms, advises installation if missing
+- `pre_upgrade`/`post_upgrade`: delegate to install hooks
+- `post_remove`: no-op
+
+## Flow
+```
+make dkms
+  → builds modules (all)              ← catches compile errors upfront
+  → checks deps (clang, makepkg, PKGBUILD, dkms.conf)
+  → makepkg -f                        ← produces applespi-dkms-0.1-1-x86_64.pkg.tar.zst
+
+sudo pacman -U applespi-dkms-0.1-1-x86_64.pkg.tar.zst
+  → copies source to /usr/src/applespi-dkms-0.1/
+  → DKMS auto-installs and builds modules
+```
+
+## Design Decisions
+- **PKGBUILD over direct dkms**: Produces a distributable package, follows AIC8800 pattern
+- **GitHub tarball source**: Ensures reproducible builds from clean state
+- **`modules: all` alias**: DKMS calls `make modules`; Makefile delegates to `all`
+- **Clang auto-detect**: Matches AIC8800 pattern, fewer compiler warnings
+- **`applespi` in `drivers/input/keyboard/`**: It's upstream since kernel 5.3
+- **iBridge in `extra/`**: Out-of-tree modules default to `extra/`
+
+## Review Fixes Applied
+| Issue | Fix |
+|---|---|
+| `source=` missing files | Added GitHub tarball source |
+| `MAKE="make modules"` would fail | Added `modules: all` alias target |
+| Self-conflicting package | Removed `provides=` and `conflicts=` |
+| Wrong module paths | applespi → `drivers/input/keyboard/`, iBridge → `extra/` |
+| Plan/implementation mismatch | Updated plan to match PKGBUILD approach |


### PR DESCRIPTION
## Summary

Add `make dkms` target that produces an installable pacman DKMS package (`applespi-dkms`), following the AIC8800-Linux-Driver pattern.

## Changes

| File | Change |
|---|---|
| `Makefile` | Clang auto-detect, `modules` alias target, `check_deps` + `dkms` targets |
| `dkms.conf` | `MAKE="make modules"` (explicit target) |
| `PKGBUILD` | New — `applespi-dkms` package, GitHub tarball source, copies all .c/.h + Makefile + dkms.conf |
| `applespi.install` | New — pacman hooks, cleans manual installs on upgrade |
| `.gitignore` | Add `*.mod` build artifacts |
| `docs/plans/dkms-target.md` | Plan document |

## Usage

```bash
make dkms                          # produces applespi-dkms-0.1-1-x86_64.pkg.tar.zst
sudo pacman -U applespi-dkms-*.pkg.tar.zst   # install package, DKMS auto-builds
```

## Review Notes

Independent review identified and fixed:
- `source=` missing files → added GitHub tarball source
- `MAKE="make modules"` would fail → added `modules: all` alias
- Self-conflicting package → removed `provides=`/`conflicts=`
- Wrong module paths in `.install` → applespi → `drivers/input/keyboard/`, iBridge → `extra/`