### PR TITLE
fix: correct header guard typo (IBRDIGE -> IBRIDGE)

### DIFF
--- a/apple-ibridge.h
+++ b/apple-ibridge.h
@@ -5,8 +5,8 @@
  * Copyright (c) 2018 Ronald Tschalär
  */
 
-#ifndef __LINUX_MFD_APPLE_IBRDIGE_H
-#define __LINUX_MFD_APPLE_IBRDIGE_H
+#ifndef __LINUX_MFD_APPLE_IBRIDGE_H
+#define __LINUX_MFD_APPLE_IBRIDGE_H
 
 #include <linux/device.h>
 #include <linux/hid.h>


### PR DESCRIPTION
Fixes #20

Changed `__LINUX_MFD_APPLE_IBRDIGE_H` to `__LINUX_MFD_APPLE_IBRIDGE_H` in both the `#ifndef` and `#define` directives.

Build passes with `make LLVM=1`.