### PR TITLE
fix: increase tp_dim_val buffer to prevent truncation

### DIFF
--- a/apple-ibridge.h
+++ b/apple-ibridge.h
@@ -5,8 +5,8 @@
  * Copyright (c) 2018 Ronald Tschalär
  */
 
-#ifndef __LINUX_MFD_APPLE_IBRDIGE_H
-#define __LINUX_MFD_APPLE_IBRDIGE_H
+#ifndef __LINUX_MFD_APPLE_IBRIDGE_H
+#define __LINUX_MFD_APPLE_IBRIDGE_H
 
 #include <linux/device.h>
 #include <linux/hid.h>

--- a/applespi.c
+++ b/applespi.c
@@ -458,7 +458,7 @@ struct applespi_data {
 
 	struct dentry			*debugfs_root;
 	bool				debug_tp_dim;
-	char				tp_dim_val[40];
+	char				tp_dim_val[64];
 	int				tp_dim_min_x;
 	int				tp_dim_max_x;
 	int				tp_dim_min_y;


### PR DESCRIPTION
Fixes #19

The 40-byte `tp_dim_val` buffer was too small for the format string used in `applespi_tp_dim_open()`, causing silent truncation. Increased to 64 bytes.

Build passes with `make LLVM=1`.