### PR TITLE
fix: add bounds check in applespi_code_to_key()

### DIFF
--- a/applespi.c
+++ b/applespi.c
@@ -1316,6 +1316,9 @@ static unsigned int applespi_translate_iso_layout(unsigned int key)
 
 static unsigned int applespi_code_to_key(u8 code, int fn_pressed)
 {
+	if (code >= ARRAY_SIZE(applespi_scancodes))
+		return 0;
+
 	unsigned int key = applespi_scancodes[code];
 
 	if (fnmode)


### PR DESCRIPTION
Fixes #18

`applespi_code_to_key()` indexes `applespi_scancodes[]` with an unvalidated `u8` value from hardware. Added a bounds check — if `code >= ARRAY_SIZE(applespi_scancodes)`, return 0.

This fixes the released-keys path (line 1370) which called this function without prior bounds checking.

Build passes with `make all`.