### PR TITLE
apple-ib-als: NULL-guard report-interval and sensitivity lookups

### DIFF
--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -432,7 +432,8 @@ static void appleals_config_sensor(struct appleals_device *als_dev,
 
 	field = appleib_find_report_field(als_dev->cfg_report,
 					 HID_USAGE_SENSOR_PROP_REPORT_INTERVAL);
-	hid_set_field(field, 0, field->logical_minimum);
+	if (field)
+		hid_set_field(field, 0, field->logical_minimum);
 
 	/*
 	 * Set initial change sensitivity; if dynamic, enabling trigger will set
@@ -443,7 +444,8 @@ static void appleals_config_sensor(struct appleals_device *als_dev,
 			HID_USAGE_SENSOR_LIGHT_ILLUM |
 			HID_USAGE_SENSOR_DATA_MOD_CHANGE_SENSITIVITY_ABS);
 
-		hid_set_field(field, 0, sensitivity);
+		if (field)
+			hid_set_field(field, 0, sensitivity);
 	}
 
 	hid_hw_request(als_dev->hid_dev, als_dev->cfg_report,


### PR DESCRIPTION
Fixes #5

Two of the four appleib_find_report_field() calls in appleals_config_sensor() dereferenced the result without a NULL check. The report-interval site reads field->logical_minimum before passing field to hid_set_field, so it crashes regardless of whether hid_set_field NULL-checks.

Brought these two sites in line with the other two lookups (which use appleals_get_field_value_for_usage(), tolerant of NULL field).

Build passes with make all.