### PR TITLE
apple-ib-tb: defer appletb_mark_active until after full initialization

### DIFF
--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -1010,9 +1010,6 @@ static int appletb_probe(struct hid_device *hdev,
 
 	/* do setup if we have both interfaces */
 	if (tb_dev->mode_info.hdev && tb_dev->disp_info.hdev) {
-		/* mark active */
-		appletb_mark_active(tb_dev, true);
-
 		/* initialize the touch bar */
 		if (appletb_tb_def_fn_mode >= 0 &&
 		    appletb_tb_def_fn_mode <= APPLETB_FN_MODE_MAX)
@@ -1025,6 +1022,8 @@ static int appletb_probe(struct hid_device *hdev,
 
 		tb_dev->cur_tb_mode = APPLETB_CMD_MODE_OFF;
 		tb_dev->cur_tb_disp = APPLETB_CMD_DISP_OFF;
+
+		appletb_mark_active(tb_dev, true);
 
 		appletb_update_touchbar(tb_dev, false);
 


### PR DESCRIPTION
Fixes #6

appletb_probe called appletb_mark_active(tb_dev, true) BEFORE initializing fn_mode, idle_timeout, dim_timeout, last_event_time, cur_tb_mode, and cur_tb_disp. A concurrent HID/event handler arriving between those steps sees active==true and reads fields with uninitialized (zero) values instead of the intended defaults.

Moved appletb_mark_active to after all field initialization and sysfs setup, so the device is only published as active once fully configured.

Build passes with make all.