### PR TITLE
apple-ib-tb: guard against NULL report_info in suspend/resume callbacks

### DIFF
--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -1111,6 +1111,7 @@ static int appletb_suspend(struct hid_device *hdev, pm_message_t message)
 {
 	struct appletb_device *tb_dev =
 		appleib_get_drvdata(hid_get_drvdata(hdev), &appletb_hid_driver);
+	struct appletb_report_info *report_info;
 	unsigned long flags;
 	bool all_suspended = false;
 
@@ -1122,6 +1123,10 @@ static int appletb_suspend(struct hid_device *hdev, pm_message_t message)
 	 * Wait for both interfaces to be suspended and no more async work
 	 * in progress.
 	 */
+	report_info = appletb_get_report_info(tb_dev, hdev);
+	if (!report_info)
+		return 0;
+
 	spin_lock_irqsave(&tb_dev->tb_lock, flags);
 
 	if (!tb_dev->mode_info.suspended && !tb_dev->disp_info.suspended) {
@@ -1129,7 +1134,7 @@ static int appletb_suspend(struct hid_device *hdev, pm_message_t message)
 		cancel_delayed_work(&tb_dev->tb_work);
 	}
 
-	appletb_get_report_info(tb_dev, hdev)->suspended = true;
+	report_info->suspended = true;
 
 	if ((!tb_dev->mode_info.hdev || tb_dev->mode_info.suspended) &&
 	    (!tb_dev->disp_info.hdev || tb_dev->disp_info.suspended))
@@ -1172,15 +1177,20 @@ static int appletb_reset_resume(struct hid_device *hdev)
 {
 	struct appletb_device *tb_dev =
 		appleib_get_drvdata(hid_get_drvdata(hdev), &appletb_hid_driver);
+	struct appletb_report_info *report_info;
 	unsigned long flags;
 
 	/*
 	 * Restore touch bar state. Note that autopm state is preserved, no need
 	 * explicitly restore that here.
 	 */
+	report_info = appletb_get_report_info(tb_dev, hdev);
+	if (!report_info)
+		return 0;
+
 	spin_lock_irqsave(&tb_dev->tb_lock, flags);
 
-	appletb_get_report_info(tb_dev, hdev)->suspended = false;
+	report_info->suspended = false;
 
 	if ((tb_dev->mode_info.hdev && !tb_dev->mode_info.suspended) &&
 	    (tb_dev->disp_info.hdev && !tb_dev->disp_info.suspended)) {


### PR DESCRIPTION
## Summary

Fixes a NULL pointer dereference in `appletb_suspend` and `appletb_reset_resume` that occurs when the T1 chip exposes an unexpected HID interface that doesn't match either the mode or display report info.

## The Bug

`appletb_get_report_info()` returns NULL when the passed `hdev` matches neither `mode_info.hdev` nor `disp_info.hdev` (apple-ib-tb.c:968). However, both suspend and reset_resume callbacks unconditionally dereference the return value:

```c
appletb_get_report_info(tb_dev, hdev)->suspended = true;   // line 1132
appletb_get_report_info(tb_dev, hdev)->suspended = false;  // line 1183
```

Since `appletb_probe` returns 0 even when `appletb_fill_report_info` returns 0 (no matching report), the driver gets attached to unrelated HID devices, and a suspend/resume cycle on such a device triggers a kernel oops.

## The Fix

Add a NULL check in both callbacks — if `appletb_get_report_info()` returns NULL, the callback returns 0 early, silently skipping the unknown HID device. This is the minimal safe fix.

## Files Changed

- `apple-ib-tb.c`: Added NULL guard in `appletb_suspend()` and `appletb_reset_resume()`