### PR TITLE
apple-ibridge: fix SRCU struct leak with devm cleanup

### DIFF
--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -755,6 +755,11 @@ static const struct hid_driver appleib_hid_driver = {
 #endif
 };
 
+static void appleib_srcu_cleanup(void *data)
+{
+	cleanup_srcu_struct(data);
+}
+
 static struct appleib_device *appleib_alloc_device(struct acpi_device *acpi_dev)
 {
 	struct appleib_device *ib_dev;
@@ -768,6 +773,9 @@ static struct appleib_device *appleib_alloc_device(struct acpi_device *acpi_dev)
 	INIT_LIST_HEAD(&ib_dev->hid_devices);
 	mutex_init(&ib_dev->update_lock);
 	init_srcu_struct(&ib_dev->lists_srcu);
+	devm_add_action_or_reset(&acpi_dev->dev,
+				 appleib_srcu_cleanup,
+				 &ib_dev->lists_srcu);
 
 	ib_dev->acpi_dev = acpi_dev;
 


### PR DESCRIPTION
Fixes #3

init_srcu_struct() was called in appleib_alloc_device() but cleanup_srcu_struct() was never called, leaking per-CPU state on every unbind and early-probe error path.

Added a devm cleanup callback via devm_add_action_or_reset() so the SRCU struct is automatically cleaned up on both the unbind path and the acpi_get_handle early-error path. Also added a typed wrapper function (appleib_srcu_cleanup) instead of casting the function pointer.

Build passes with make all.