### PR TITLE
apple-ib-tb: add comment and validation for USB endpoint in appletb_fill_report_info

### DIFF
--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -940,9 +940,24 @@ static int appletb_fill_report_info(struct appletb_device *tb_dev,
 		return -ENODEV;
 	}
 
+	/* Validate interface configuration */
+	if (!usb_iface->cur_altsetting ||
+	    usb_iface->cur_altsetting->desc.bNumEndpoints == 0) {
+		dev_err(tb_dev->log_dev,
+			"Invalid USB interface configuration for hid device %s\n",
+			dev_name(&hdev->dev));
+		return -ENODEV;
+	}
+
 	report_info->hdev = hdev;
 
 	report_info->usb_iface = usb_get_intf(usb_iface);
+
+	/*
+	 * Endpoint 0 is the default control endpoint, which is always present
+	 * on every USB device per the USB specification. HID control transfers
+	 * use this endpoint, so it is correct for these reports.
+	 */
 	report_info->usb_epnum = 0;
 
 	report_info->report_id = field->report->id;


### PR DESCRIPTION
## Summary

- Add a comment explaining why usb_epnum = 0 is correct for HID control transfers (endpoint 0 is the default control endpoint per USB spec)
- Add validation during probe to ensure the USB interface has a valid alternate setting with at least one endpoint descriptor

## Changes

- apple-ib-tb.c: Added inline comment in appletb_fill_report_info() documenting the USB endpoint choice
- apple-ib-tb.c: Added interface configuration validation in appletb_fill_report_info() to catch misconfigurations early

Fixes #28