### PR TITLE
copyright: update copyright years to 2026

### DIFF
--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -2,7 +2,7 @@
 /*
  * Apple Ambient Light Sensor Driver
  *
- * Copyright (c) 2017-2018 Ronald Tschalär
+ * Copyright (c) 2017-2026 Ronald Tschalär
  */
 
 /*

--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -2,7 +2,7 @@
 /*
  * Apple Touch Bar Driver
  *
- * Copyright (c) 2017-2018 Ronald Tschalär
+ * Copyright (c) 2017-2026 Ronald Tschalär
  */
 
 /*

--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -2,7 +2,7 @@
 /*
  * Apple iBridge Driver
  *
- * Copyright (c) 2018 Ronald Tschalär
+ * Copyright (c) 2018-2026 Ronald Tschalär
  */
 
 /**

--- a/apple-ibridge.h
+++ b/apple-ibridge.h
@@ -2,7 +2,7 @@
 /*
  * Apple iBridge Driver
  *
- * Copyright (c) 2018 Ronald Tschalär
+ * Copyright (c) 2018-2026 Ronald Tschalär
  */
 
 #ifndef __LINUX_MFD_APPLE_IBRIDGE_H

--- a/applespi.c
+++ b/applespi.c
@@ -2,8 +2,8 @@
 /*
  * MacBook (Pro) SPI keyboard and touchpad driver
  *
- * Copyright (c) 2015-2018 Federico Lorenzi
- * Copyright (c) 2017-2018 Ronald Tschalär
+ * Copyright (c) 2015-2026 Federico Lorenzi
+ * Copyright (c) 2017-2026 Ronald Tschalär
  */
 
 /*

--- a/applespi.h
+++ b/applespi.h
@@ -2,8 +2,8 @@
 /*
  * MacBook (Pro) SPI keyboard and touchpad driver
  *
- * Copyright (c) 2015-2019 Federico Lorenzi
- * Copyright (c) 2017-2019 Ronald Tschalär
+ * Copyright (c) 2015-2026 Federico Lorenzi
+ * Copyright (c) 2017-2026 Ronald Tschalär
  */
 
 #ifndef _APPLESPI_H_

--- a/applespi_trace.h
+++ b/applespi_trace.h
@@ -2,8 +2,8 @@
 /*
  * MacBook (Pro) SPI keyboard and touchpad driver
  *
- * Copyright (c) 2015-2019 Federico Lorenzi
- * Copyright (c) 2017-2019 Ronald Tschalär
+ * Copyright (c) 2015-2026 Federico Lorenzi
+ * Copyright (c) 2017-2026 Ronald Tschalär
  */
 
 #undef TRACE_SYSTEM


### PR DESCRIPTION
Refresh stale copyright years across all source files to reflect current year (2026), making it easier to assess how recently files have been modified.

Fixes #27