### PR TITLE
apple-ibridge: NULL check udev->actconfig in probe

### DIFF
--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -665,6 +665,9 @@ static int appleib_hid_probe(struct hid_device *hdev,
 	/* check and set usb config first */
 	udev = hid_to_usb_dev(hdev);
 
+	if (!udev->actconfig)
+		return -ENODEV;
+
 	if (udev->actconfig->desc.bConfigurationValue != APPLETB_BASIC_CONFIG) {
 		rc = usb_driver_set_configuration(udev, APPLETB_BASIC_CONFIG);
 		return rc ? rc : -ENODEV;


### PR DESCRIPTION
## Summary

`appleib_hid_probe` dereferences `udev->actconfig->desc.bConfigurationValue` without verifying `udev->actconfig` is non-NULL.

## Why it matters

In the normal enumeration path `actconfig` is set before HID probes run, but it is not strictly guaranteed in all USB error/reconfiguration paths (e.g. config change races, authorization transitions). A NULL `actconfig` produces a kernel oops.

Low severity — defensive hardening.

## Fix

Add `if (!udev->actconfig) return -ENODEV;` before dereferencing `udev->actconfig`.

Fixes #17
