### PR TITLE
Fix missing prototype warning for appleib_detach_and_free_hid_driver

### DIFF
--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -189,7 +189,7 @@ static void appleib_remove_device(struct appleib_device *ib_dev,
 	kfree(dev_info);
 }
 
-void appleib_detach_and_free_hid_driver(struct appleib_device *ib_dev,
+static void appleib_detach_and_free_hid_driver(struct appleib_device *ib_dev,
 					struct appleib_hid_drv_info *drv_info)
 {
 	appleib_detach_devices(ib_dev, drv_info->driver);


### PR DESCRIPTION
## Build Warning

```
apple-ibridge.c:192:6: warning: no previous prototype for function 'appleib_detach_and_free_hid_driver' [-Wmissing-prototypes]
  192 | void appleib_detach_and_free_hid_driver(struct appleib_device *ib_dev,
      |      ^
apple-ibridge.c:192:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
```

## Details

- **File:** `apple-ibridge.c:192`
- **Function:** `appleib_detach_and_free_hid_driver`
- **Warning:** `-Wmissing-prototypes`

## Suggested Fix

Either:
1. Add a function declaration (prototype) in the header file `apple-ibridge.h` if the function is meant to be used externally, or
2. Add the `static` keyword to the function definition if it is only used within `apple-ibridge.c`

## Reproduction

```bash
make clean && make all
```
