### PR TITLE
Fix switch warning by returning -EINVAL for unhandled report types

### DIFF
--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -968,6 +968,8 @@ static int appletb_fill_report_info(struct appletb_device *tb_dev,
 		report_info->report_type = 0x02; break;
 	case HID_FEATURE_REPORT:
 		report_info->report_type = 0x03; break;
+	default:
+		return -EINVAL;
 	}
 
 	return 1;


### PR DESCRIPTION
## Problem

Build warning (clang -Wswitch):

```
apple-ib-tb.c:964:10: warning: enumeration value 'HID_REPORT_TYPES' not handled in switch [-Wswitch]
  964 |         switch (field->report->type) {
      |                 ^~~~~~~~~~~~~~~~~~~
```

## Correct Fix

`HID_REPORT_TYPES` is the kernel's enum sentinel (count value, not a real report type). It should never appear in valid HID data.

Without a default case, if `HID_REPORT_TYPES` (or any future enum addition) slips through, `report_info->report_type` is left at zero (from `devm_kzalloc` default) and the function still returns 1 (success). That zero is then used in `usb_control_msg` requests as if it were a valid report type -- silent corruption.

**Fix:** Add `default: return -EINVAL;` to the switch. Caller already handles error returns. This correctly treats the sentinel and any future enum additions as failures.

## Why not other options?

- `case HID_REPORT_TYPES: return -EINVAL;` -- explicit but brittle: a future `enum hid_report_type` extension would re-introduce the same `-Wswitch` warning.
- Empty `default: break;` -- silences the warning but **preserves the silent-zero bug**. Wrong fix.
